### PR TITLE
remove --build-path-root option again, update docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,12 +94,6 @@ function yargsOptions(yargs) {
         group: "Action options:",
         describe: "Path to built action, result of --on-build command"
     });
-    yargs.option("build-path-root", {
-      type: "string",
-      group: "Action options:",
-      describe: "Build path mount root, requires --build-path",
-      coerce: path.resolve // ensure absolute path
-    });
 
     // source watching
     yargs.option("l", {

--- a/src/debugger.js
+++ b/src/debugger.js
@@ -778,7 +778,7 @@ class Debugger {
             this.liveReloadServer = livereload.createServer({
                 port: this.argv.livereloadPort,
                 noListen: !this.argv.livereload,
-                exclusions: [this.argv.buildPath, this.argv.buildPathRoot],
+                exclusions: [this.argv.buildPath],
                 extraExts: this.argv.watchExts || ["json", "go", "java", "scala", "php", "py", "rb", "swift", "rs", "cs", "bal"]
             });
             this.liveReloadServer.watch(watch);

--- a/src/invoker.js
+++ b/src/invoker.js
@@ -65,7 +65,7 @@ class OpenWhiskInvoker {
         // the build path can be separate, if not, same as the source/watch path
         this.sourcePath = options.buildPath || options.sourcePath;
         if (this.sourcePath) {
-            this.sourceDir = options.buildPathRoot ? path.resolve(options.buildPathRoot) : process.cwd();
+            this.sourceDir = process.cwd();
             // ensure sourcePath is relative to sourceDir
             this.sourceFile = path.relative(this.sourceDir, this.sourcePath);
         }

--- a/test/nodejs.test.js
+++ b/test/nodejs.test.js
@@ -144,7 +144,7 @@ describe('nodejs', function() {
         test.assertAllNocksInvoked();
       });
 
-      it("should mount local sources with a require(../) dependency and --build-path-root set", async function() {
+      it("should mount local sources with a require(../) dependency and run build with --on-build set", async function() {
         this.timeout(10000);
         test.mockActionAndInvocation(
             "myaction",
@@ -159,7 +159,7 @@ describe('nodejs', function() {
 
         // simulate a build that moves things into a separate directory with different naming
         const onBuild = "mkdir -p build/out; cp -R lib build/out/folder; cp dependency.js build/out";
-        await wskdebug(`myaction lib/action.js --on-build '${onBuild}' --build-path build/out/folder/action.js --build-path-root build/out -p ${test.port}`);
+        await wskdebug(`myaction lib/action.js --on-build '${onBuild}' --build-path build/out/folder/action.js -p ${test.port}`);
 
         fse.removeSync("build");
         test.assertAllNocksInvoked();


### PR DESCRIPTION
Follow up from #35. `--build-path-root` is not really required in normal cases - when the build folder is somewhere inside the current working directory.